### PR TITLE
fix lambda retries for DLQ

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -79,6 +79,7 @@ awslocal lambda create-function \
     --environment Variables="{STAGE=local}"
 
 awslocal lambda wait function-active-v2 --function-name resize
+awslocal lambda put-function-event-invoke-config --function-name resize --maximum-event-age-in-seconds 3600 --maximum-retry-attempts 0
 
 awslocal s3api put-bucket-notification-configuration \
     --bucket localstack-thumbnails-app-images \


### PR DESCRIPTION
The sample started to fail lately with the following test: `test_failure_sns_to_ses_integration`

This test is making a lambda fail, and checks that the Lambda is properly triggering and sending a message to its DLQ, here an SNS topic, which forwards it to SES. We then access the SES internal endpoint to fetch the data.

As recent changes to put lambda in line with AWS regarding DLQ behaviours were done, this was now failing: lambda will retry before sending the message in the DLQ. We set the retries to `0` so that the message arrives fast in the topic, which forwards it to SNS.

The message was a bit cryptic, because as lambda didn't send it yet to SNS, the message was not yet forward to SES, so the provider was not loaded, and the internal endpoint not registered yet. 

The test now passes locally for me on latest.