### PR TITLE
update workflows for cloudpod + README

### DIFF
--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -60,6 +60,8 @@ jobs:
           pytest tests
       
       - name: Save the Cloud Pod 
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         uses: HarshCasper/cloud-pod-save@v0.1.0
         with:
           name: 'release-pod.zip'

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -62,10 +62,8 @@ jobs:
       - name: Save the Cloud Pod 
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
-        uses: HarshCasper/cloud-pod-save@v0.1.0
-        with:
-          name: 'release-pod.zip'
-          location: 'disk'
+        run: | 
+          localstack state export release-pod.zip
 
       - name: Prepare Release Notes
         run: |

--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Prepare Release Notes
         run: |
           echo "This release includes the Cloud Pod of the sample created with LocalStack Version \`${{ inputs.release-tag || 'latest'}}\`." > Release.txt
-          echo "You can download the \`release-pod.zip\` and inject it manually by running \`localstack pod load file://release-pod.zip\`, or use the Cloud Pods Launchpad." >> Release.txt
+          echo "You can download the \`release-pod.zip\` and inject it manually by running \`localstack state import release-pod.zip\`, or use the Cloud Pods Launchpad." >> Release.txt
           echo "### Cloud Pods Launchpad" >> Release.txt
           echo "You can click the Launchpad to inject the the pod into your running LocalStack instance using the WebUI:" >> Release.txt
           echo "[![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/$GITHUB_REPOSITORY/releases/download/${{ inputs.release-tag || 'latest'}}/release-pod.zip)" >> Release.txt

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -69,6 +69,8 @@ jobs:
           echo "Startup complete"
 
       - name: Inject Pod
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           localstack pod load file://release-pod.zip
 

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
-          localstack state import file://release-pod.zip
+          localstack state import release-pod.zip
 
       - name: Run Tests
         env:

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
-          localstack pod load file://release-pod.zip
+          localstack state import file://release-pod.zip
 
       - name: Run Tests
         env:

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ Please refer to the [contributing file](CONTRIBUTING.md) for more details on how
 [Cloud Pods](https://docs.localstack.cloud/user-guide/tools/cloud-pods/) are a mechanism that allows you to take a snapshot of the state in your current LocalStack instance, persist it to a storage backend, and easily share it with your team members.
 
 You can convert your current AWS infrastructure state to a Cloud Pod using the `localstack` CLI. 
-Check out our [Getting Started guide](https://docs.localstack.cloud/user-guide/tools/cloud-pods/getting-started/) and [LocalStack Cloud Pods CLI reference](https://docs.localstack.cloud/user-guide/tools/cloud-pods/pods-cli/) to learn more about Cloud Pods and how to use them.
+Check out our [Getting Started guide](https://docs.localstack.cloud/user-guide/cloud-pods/getting-started/) and [LocalStack Cloud Pods CLI reference](https://docs.localstack.cloud/user-guide/cloud-pods/pods-cli/ to learn more about Cloud Pods and how to use them.
 
-To inject a Cloud Pod you can use [Cloud Pods Launchpad](https://docs.localstack.cloud/user-guide/tools/cloud-pods/launchpad/) wich quickly injects Cloud Pods into your running LocalStack container. 
+To inject a Cloud Pod you can use [Cloud Pods Launchpad](https://docs.localstack.cloud/user-guide/cloud-pods/launchpad/) wich quickly injects Cloud Pods into your running LocalStack container. 
 
 Click here [![LocalStack Pods Launchpad](https://localstack.cloud/gh/launch-pod-badge.svg)](https://app.localstack.cloud/launchpad?url=https://github.com/localstack/sample-serverless-image-resizer-s3-lambda/releases/download/latest/release-pod.zip) to launch the Cloud Pods Launchpad and inject the Cloud Pod for this application by clicking the `Inject` button.
 
@@ -261,5 +261,5 @@ First, you need to download the pod you want to inject from the [releases](https
 Then run:
 
 ```sh
-localstack pod load file://$(pwd)/release-pod.zip
+localstack state import /path/to/release-pod.zip
 ```


### PR DESCRIPTION
updated the workflows for releasing and testing cloudpods:
- adding the LOCALSTACK_API_KEY which is required now
- updating the commands to save and load pods to/from disk
   - already [updated the latest pod release](https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda/actions/runs/7246890229)
   - [test run successfully](https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda/actions/runs/7247060556)

updated README: 
- the cloudpod links were all invalid
- update command to inject pod from disk