### PR TITLE
fix sample on Safari

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -95,4 +95,4 @@ awslocal lambda list-function-url-configs --function-name presign | jq -r '.Func
 echo "Fetching function URL for 'list' Lambda..."
 awslocal lambda list-function-url-configs --function-name list | jq -r '.FunctionUrlConfigs[0].FunctionUrl'
 
-echo "Now open the Web app under https://webapp.s3.localhost.localstack.cloud/index.html and paste the function URLs above (make sure to use https:// as protocol)"
+echo "Now open the Web app under https://webapp.s3-website.localhost.localstack.cloud and paste the function URLs above (make sure to use https:// as protocol)"

--- a/website/app.js
+++ b/website/app.js
@@ -19,15 +19,19 @@
             event.returnValue = false;
 
         event.preventDefault();
-
         let action = $(this).find("button[type=submit]:focus").attr('name');
+        if (action === undefined) {
+            // the jquery find with the focus does not work on Safari, maybe because the focus is not instantly given
+            // fallback to manually retrieving the submitter from the original event
+            action = event.originalEvent.submitter.getAttribute('name')
+        }
 
         if (action == "load") {
             let baseUrl = `${document.location.protocol}//${document.location.host}`;
             if (baseUrl.indexOf("file://") >= 0) {
                 baseUrl = `http://localhost:4566`;
             }
-            baseUrl = baseUrl.replace("://webapp.s3.", "://");
+            baseUrl = baseUrl.replace("://webapp.s3.", "://").replace("://webapp.s3-website.", "://");
             const headers = {authorization: "AWS4-HMAC-SHA256 Credential=test/20231004/us-east-1/lambda/aws4_request, ..."};
             const loadUrl = async (funcName, resultElement) => {
                 const url = `${baseUrl}/2021-10-31/functions/${funcName}/urls`;


### PR DESCRIPTION
The sample would not work on Safari, I think because the `find` clause with an action pseudo-class `focus` on the form button would not match. We can manually fall back on the emitted event submitter and return the attribute from there. 

Also fixed the `Load from API` button to also replace the S3 Website prefix to use the base URL to fetch the lambda functions URL.

Replaced the returned S3 URL to properly use the S3 website (which has the proper redirect from `/` to `index.html`, and automatic CORS handling). 