### PR TITLE
fix(docs): Fix resizing lambda packaging on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ awslocal lambda create-function-url-config \
     cd lambdas/resize
     rm -rf package lambda.zip
     mkdir package
-    pip install -r requirements.txt -t package
+    pip install -r requirements.txt -t package --platform manylinux2014_x86_64 --only-binary=:all:
     zip lambda.zip handler.py
     cd package
     zip -r ../lambda.zip *;


### PR DESCRIPTION
# Motivation
Resizing lambda won't work if it's packaged on MacOS with arm binaries while the lambda runs on Linux.
Following the README ended up with the following:
```
Runtime.ImportModuleError: Unable to import module 'handler': cannot import name '_imaging' from 'PIL' (/var/Traceback (most recent call last):
```
# Changes
- update docs with right switches