### PR TITLE
Change macos runner triggers

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,13 +13,18 @@ on:
     # “At 00:00 on Sunday.”
     - cron: "0 0 * * 0"
   workflow_dispatch:
+    inputs:
+      runner-os:
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-latest
+
 
 jobs:
   run-it-tests-job:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ inputs.runner-os || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# Motivation
MacOs runners are failing regularly, however by manual triggers usually succeeds. Because of this unreliability we decided to turn off auto triggers and add an input option to manual triggers.

<img width="1133" alt="image" src="https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda/assets/43646571/19f29d8e-86c0-44eb-afd2-8688996f3772">

# Changes
- remove os matrix
- add input to workflow_dispatch
- set default runner to ubuntu