### PR TITLE
fix S3 post not passing all fields

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -51,7 +51,7 @@ if [ "$os" == "Darwin" ]; then
     (
         cd lambdas/resize
         rm -rf libs lambda.zip
-        docker run --platform linux/x86_64 -v "$PWD":/var/task "public.ecr.aws/sam/build-python3.9" /bin/sh -c "pip install -r requirements.txt -t libs; exit"
+        docker run --platform linux/x86_64 --rm -v "$PWD":/var/task "public.ecr.aws/sam/build-python3.9" /bin/sh -c "pip install -r requirements.txt -t libs; exit"
         cd libs && zip -r ../lambda.zip . && cd ..
         zip lambda.zip handler.py
         rm -rf libs

--- a/lambdas/presign/handler.py
+++ b/lambdas/presign/handler.py
@@ -31,7 +31,10 @@ def handler(event, context):
         raise ValueError("no key given")
 
     # make sure the bucket exists
-    s3.create_bucket(Bucket=bucket)
+    try: 
+        s3.head_bucket(Bucket=bucket)
+    except Exception:
+        s3.create_bucket(Bucket=bucket)
 
     # make sure the object does not exist
     try:

--- a/website/app.js
+++ b/website/app.js
@@ -78,21 +78,23 @@
         let urlToCall = functionUrlPresign + "/" + fileName
         console.log(urlToCall);
 
-        let form = this;
-
         $.ajax({
             url: urlToCall,
             success: function (data) {
                 console.log("got pre-signed POST URL", data);
 
-                // set form fields to make it easier to serialize
                 let fields = data['fields'];
-                $(form).attr("action", data['url']);
-                for (let key in fields) {
-                    $("#" + key).val(fields[key]);
-                }
 
-                let formData = new FormData($("#uploadForm")[0]);
+                let formData = new FormData()
+                
+                Object.entries(fields).forEach(([field, value]) => {
+                    formData.append(field, value);
+                });
+
+                // the file <input> element, "file" needs to be the last element of the form
+                const fileElement = document.querySelector("#customFile");
+                formData.append("file", fileElement.files[0]);
+
                 console.log("sending form data", formData);
 
                 $.ajax({


### PR DESCRIPTION
We've had an issue since the LocalStack PR: https://github.com/localstack/localstack/pull/10616, raised by @thrau

![image (2)](https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda/assets/42031100/858ffa6b-f69e-4ffd-9200-4d18697bdd9f)


We've added better validation of S3 POST policy conditions, and some SDK set them automatically like in this case.
But when creating and passing the form, we would not forward all the fields created by the pre-signed POST, so the validation would fail. 

I've also created an AWS validated test here: https://github.com/localstack/localstack/pull/10641
To validate that LocalStack handles it correctly (we might return some different exceptions in case of invalid credentials, but that's alright for now). Anyway, AWS does not ignore any fields and will fail as well if we would try to do what the sample does at the moment.

I've created the form manually and appended the fields to it:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects

The `file` field needs to be last, so I've created the form from scratch instead of using the element to fetch it. Otherwise, we would need to create hidden fields in the form for every field returned by the pre-signed. 

Also see https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-s3-presigned-post/ for the pre-signed POST doc on how you can use it in browser. 

I've also sneaked a fix to properly delete the build image when running on macOS. 

Also did a quick S3 change in the lambda creating the pre-signed, as we would always call `create_bucket` to check the bucket exists, but this is only omnipotent in `us-east-1` and would raise an exception if done in any other region, so I've did it with `head_bucket` instead. 