### PR TITLE
Pin CircleCI env on Python 3.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,9 @@ jobs:
       - run:
           name: Install Python 3.11
           command: |
-            test -d /opt/circleci/.pyenv/versions/3.11.6 || pyenv install 3.11.6
-            pyenv global 3.11.6
+            # Currently highest available 3.11 on CircleCI runner
+            test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
+            pyenv global 3.11.1
       - localstack/start        
       - run:
           name: Install dependencies
@@ -38,7 +39,7 @@ jobs:
             - ls-state.zip
       - save_cache:
           paths:
-            - /opt/circleci/.pyenv/versions/3.11.6
+            - /opt/circleci/.pyenv/versions/3.11.1
           key: python-deps-{{ checksum "requirements-dev.txt" }}
       - store_artifacts:
           path: ls-state.zip
@@ -59,7 +60,7 @@ jobs:
       - run:
           name: Choose python version
           command:
-            pyenv global 3.11.6
+            pyenv global 3.11.1
       - localstack/start        
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
   save-state:
     executor: localstack/default
     steps:
+      - checkout
       - restore_cache:
           keys:
             - python-deps-{{ checksum "requirements-dev.txt" }}
@@ -19,7 +20,6 @@ jobs:
             test -d /opt/circleci/.pyenv/versions/3.11.6 || pyenv install 3.11.6
             pyenv global 3.11.6
       - localstack/start        
-      - checkout
       - run:
           name: Install dependencies
           command:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
             - python-deps-{{ checksum "requirements-dev.txt" }}
             - python-deps
       - run:
-          name: Install Python 3.9
+          name: Install Python 3.11
           command: |
-            test -d /opt/circleci/.pyenv/versions/3.9.16 || pyenv install 3.9.16
-            pyenv global 3.9.16
+            test -d /opt/circleci/.pyenv/versions/3.11.6 || pyenv install 3.11.6
+            pyenv global 3.11.6
       - localstack/start        
       - checkout
       - run:
@@ -38,7 +38,7 @@ jobs:
             - ls-state.zip
       - save_cache:
           paths:
-            - /opt/circleci/.pyenv/versions/3.9.16
+            - /opt/circleci/.pyenv/versions/3.11.6
           key: python-deps-{{ checksum "requirements-dev.txt" }}
       - store_artifacts:
           path: ls-state.zip
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Choose python version
           command:
-            pyenv global 3.9.16
+            pyenv global 3.11.6
       - localstack/start        
       - checkout
       - run:


### PR DESCRIPTION
# Motivation
CircleCI was pinned to 3.9.x, now as we've bumped up the version to 3.11 we use 3.11.1 version as this is the current highest available on the CircleCI runners.

# Changes
- CircleCI pyenv version bump