### PR TITLE
Fix name resolution issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,9 @@ default:
     - mkdir -p $PIP_CACHE_DIR
     - python3 -m pip install localstack awscli awscli-local
     - docker pull localstack/localstack-pro:latest
-    - dind_ip="$(getent hosts docker | cut -d' ' -f1)"
-    - echo "${dind_ip} localhost.localstack.cloud " >> /etc/hosts
+    # Gitlab has changed to ipv6, but LocalStack not supporting it
+    - dind_ip="$(getent ahostsv4 docker | cut -d' ' -f1 | head -n1)"
+    - echo -e "${dind_ip}\tlocalhost.localstack.cloud\n" >> /etc/hosts
     - localstack start -d
     - localstack wait -t 30
     - (test -f ./ls-state-pod.zip && localstack state import ./ls-state-pod.zip) || true
@@ -57,7 +58,6 @@ deploy:
   script:
     - ./bin/deploy.sh
     - localstack state export ./ls-state-pod.zip
-    - localstack logs
 
 test:
   stage: test
@@ -69,6 +69,8 @@ test:
         - .circleci/*
         - .github/*
     - when: always
+  needs:
+    - deploy
   before_script:
     - *default_before_scripts
     - python3 -m pip install -r requirements-dev.txt


### PR DESCRIPTION
# Motivation
GitLab enforces ipv6 now, however LocalStack has issues with it. So we need to work this around by getting the IPv4 address of the docker service.

# Changes
- use getent to get IPv4 address