### PR TITLE
Fix arguments passed to awslocal

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -82,7 +82,7 @@ awslocal lambda create-function \
 awslocal lambda wait function-active-v2 --function-name resize
 awslocal lambda put-function-event-invoke-config --function-name resize --maximum-event-age-in-seconds 3600 --maximum-retry-attempts 0
 
-fn_resize_arn=$(awslocal lambda get-function --function-name resize | jq -r .Configuration.FunctionArn)
+fn_resize_arn=$(awslocal lambda get-function --function-name resize --output json | jq -r .Configuration.FunctionArn)
 awslocal s3api put-bucket-notification-configuration \
     --bucket localstack-thumbnails-app-images \
     --notification-configuration "{\"LambdaFunctionConfigurations\": [{\"LambdaFunctionArn\": \"$fn_resize_arn\", \"Events\": [\"s3:ObjectCreated:*\"]}]}"
@@ -93,9 +93,9 @@ awslocal s3 website s3://webapp --index-document index.html
 
 echo
 echo "Fetching function URL for 'presign' Lambda..."
-awslocal lambda list-function-url-configs --function-name presign | jq -r '.FunctionUrlConfigs[0].FunctionUrl'
+awslocal lambda list-function-url-configs --function-name presign --output json | jq -r '.FunctionUrlConfigs[0].FunctionUrl'
 echo "Fetching function URL for 'list' Lambda..."
-awslocal lambda list-function-url-configs --function-name list | jq -r '.FunctionUrlConfigs[0].FunctionUrl'
+awslocal lambda list-function-url-configs --function-name list --output json | jq -r '.FunctionUrlConfigs[0].FunctionUrl'
 
 echo "Now open the Web app under https://webapp.s3-website.localhost.localstack.cloud:4566/"
 echo "and paste the function URLs above (make sure to use https:// as protocol)"


### PR DESCRIPTION
`jq` needs JSON output to parse the configuration. This fixes the used commands.