### PR TITLE
Add devcontainer setups

### DIFF
--- a/.devcontainer/docker-in-docker/devcontainer.json
+++ b/.devcontainer/docker-in-docker/devcontainer.json
@@ -1,0 +1,56 @@
+{
+	"name": "LocalStack DinD setup",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	"remoteEnv": {
+		// Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+		"LOCALSTACK_AUTH_TOKEN": "${localEnv:LOCALSTACK_AUTH_TOKEN}",  // required for Pro, not processed via template due to security reasons
+		"LOCALSTACK_API_KEY": "${localEnv:LOCALSTACK_API_KEY}",
+		// LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+		"ACTIVATE_PRO": true,
+		"DEBUG": true,
+		"LS_LOG": "trace",
+		"PERSISTENCE": false,
+		"AWS_ENDPOINT_URL": "http://localhost.localstack.cloud:4566",
+		"AUTO_LOAD_POD": "",
+		"ENFORCE_IAM": false,
+		"AWS_REGION": "us-east-1",
+		"AWS_DEFAULT_REGION": "us-east-1",
+		"IMAGE_NAME": "localstack/localstack-pro:latest",
+		"LOCALSTACK_VOLUME_DIR": "/data"
+	},
+
+	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/localstack/devcontainer-feature/localstack-cli:latest": {
+			"version": "latest",
+			"awslocal": true,  // if true, add in features manually: ghcr.io/devcontainers/features/aws-cli
+			"cdklocal": false,  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/aws-cdk
+			"pulumilocal": false,  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/pulumi
+			"samlocal": false,  // if true, add in features manually: ghcr.io/customink/codespaces-features/sam-cli
+			"tflocal": false  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/terraform-asdf
+		},
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.11"
+		}
+	},
+
+	// 👇 Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "type localstack; true && localstack start -d || true",
+	"mounts": [
+		{
+			// to persist build data and images
+			"source": "dind-var-lib-docker",
+			"target": "/var/lib/docker",
+			"type": "volume"
+		}, 
+		{ 
+			"source": "./.volume",
+			"target": "/data",
+			"type": "bind",
+			"consistency": "cached"
+		}
+	]
+}

--- a/.devcontainer/docker-outside-of-docker/.env
+++ b/.devcontainer/docker-outside-of-docker/.env
@@ -1,0 +1,15 @@
+# Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for Pro, not processed via template due to security reasons
+LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:-}
+# LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+ACTIVATE_PRO=true
+DEBUG=true
+LS_LOG=trace
+PERSISTENCE=false
+AWS_ENDPOINT_URL=http://localhost.localstack.cloud:4566
+LOCALSTACK_HOST=localhost.localstack.cloud:4566
+AUTO_LOAD_POD=
+ENFORCE_IAM=false
+AWS_REGION=us-east-1
+AWS_DEFAULT_REGION=us-east-1
+IMAGE_NAME=localstack/localstack-pro:latest

--- a/.devcontainer/docker-outside-of-docker/.volume/.gitkeep
+++ b/.devcontainer/docker-outside-of-docker/.volume/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this folder for DevContainers DooD setup

--- a/.devcontainer/docker-outside-of-docker/Dockerfile
+++ b/.devcontainer/docker-outside-of-docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm

--- a/.devcontainer/docker-outside-of-docker/devcontainer.json
+++ b/.devcontainer/docker-outside-of-docker/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "LocalStack DooD setup",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/localstack/devcontainer-feature/localstack-cli:latest": {
+			"version": "latest",
+			"awslocal": true,  // if true, add in features manually: ghcr.io/devcontainers/features/aws-cli
+			"cdklocal": false,  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/aws-cdk
+			"pulumilocal": false,  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/pulumi
+			"samlocal": false,  // if true, add in features manually: ghcr.io/customink/codespaces-features/sam-cli
+			"tflocal": false  // if true, add in features manually: ghcr.io/devcontainers-contrib/features/terraform-asdf
+		},
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.11"
+		}
+	}
+}

--- a/.devcontainer/docker-outside-of-docker/docker-compose.yml
+++ b/.devcontainer/docker-outside-of-docker/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  localstack:
+    container_name: "localstack-main"
+    image: localstack/localstack-pro:latest  # required for Pro
+    ports:
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (Pro)
+    env_file:
+      - .env
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./.volume:/var/lib/localstack"
+    networks:
+      ls:
+        # Set the container IP address in the info subnet
+        ipv4_address: 10.0.2.20
+  
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    init: true
+    env_file:
+      - .env
+    dns:
+      # Set the DNS server to be the LocalStack container
+      - 10.0.2.20
+    networks:
+      - ls
+
+networks:
+  ls:
+    ipam:
+      config:
+        # Specify the subnet range for IP address allocation
+        - subnet: 10.0.2.0/24

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ package-lock.json
 /nosetests.xml
 
 .env
+!.devcontainer/**/.env
 venv
 /.venv*
 /.coverage

--- a/.volume/.gitkeep
+++ b/.volume/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this folder for DevContainers DinD setup


### PR DESCRIPTION
# Motivation
With our DevContainer Feature and Templates live we'd like to showcase the simplicity and flexibility of its usage by adding a Docker-in-Docker (DinD) and a Docker-outside-of-Docker (DooD) setup.

# Changes
- add DinD setup
- add DooD setup