### PR TITLE
update artifacts GitHub actions to v4

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload the Diagnostic Report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diagnose.json.gz
           path: ./diagnose.json.gz


### PR DESCRIPTION
## Motivation
GitHub is currently phasing out support for `actions/upload-artifact` and `actions/download-artifact` versions other than the latest major release v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting December 5, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

This PR updates the the action to v4.

## Changes
Update the GitHub artifact action versions to v4 before the burn-down.