### PR TITLE
zip with packaging added to create lambda function in deployment shel…

### DIFF
--- a/deployment/awslocal/deploy.sh
+++ b/deployment/awslocal/deploy.sh
@@ -14,6 +14,7 @@ awslocal sns subscribe \
     --protocol email \
     --notification-endpoint my-email@example.com
 
+(cd lambdas/presign; rm -f lambda.zip; zip lambda.zip handler.py)
 awslocal lambda create-function \
     --function-name presign \
     --runtime python3.11 \
@@ -29,6 +30,7 @@ awslocal lambda create-function-url-config \
     --function-name presign \
     --auth-type NONE
 
+(cd lambdas/list; rm -f lambda.zip; zip lambda.zip handler.py)
 awslocal lambda create-function \
     --function-name list \
     --runtime python3.11 \
@@ -44,7 +46,15 @@ awslocal lambda create-function-url-config \
     --function-name list \
     --auth-type NONE
 
-
+(
+    cd lambdas/resize
+    rm -rf package lambda.zip
+    mkdir package
+    pip install -r requirements.txt -t package --platform manylinux2014_x86_64 --only-binary=:all:
+    zip lambda.zip handler.py
+    cd package
+    zip -r ../lambda.zip *;
+)
 awslocal lambda create-function \
     --function-name resize \
     --runtime python3.11 \


### PR DESCRIPTION
Solve: localstack-samples/sample-serverless-image-resizer-s3-lambda#39

This PR includes,

1. Remove the zip file of lambda function if exists.
2. Then, create the zip file of lambda function using `zip` command.

_Note: It's been already shared in the [readme](https://github.com/localstack-samples/sample-serverless-image-resizer-s3-lambda#resizer-lambda)_