### PR TITLE
fix the resize lambda by removing redundant zip step

### DIFF
--- a/deployment/awslocal/deploy.sh
+++ b/deployment/awslocal/deploy.sh
@@ -14,7 +14,6 @@ awslocal sns subscribe \
     --protocol email \
     --notification-endpoint my-email@example.com
 
-(cd lambdas/presign; rm -f lambda.zip; zip lambda.zip handler.py)
 awslocal lambda create-function \
     --function-name presign \
     --runtime python3.11 \
@@ -29,8 +28,6 @@ awslocal lambda wait function-active-v2 --function-name presign
 awslocal lambda create-function-url-config \
     --function-name presign \
     --auth-type NONE
-
-(cd lambdas/list; rm -f lambda.zip; zip lambda.zip handler.py)
 awslocal lambda create-function \
     --function-name list \
     --runtime python3.11 \
@@ -46,15 +43,6 @@ awslocal lambda create-function-url-config \
     --function-name list \
     --auth-type NONE
 
-(
-    cd lambdas/resize
-    rm -rf package lambda.zip
-    mkdir package
-    pip install -r requirements.txt -t package --platform manylinux2014_x86_64 --only-binary=:all:
-    zip lambda.zip handler.py
-    cd package
-    zip -r ../lambda.zip *;
-)
 awslocal lambda create-function \
     --function-name resize \
     --runtime python3.11 \


### PR DESCRIPTION
## Description

The PR #40 added extra steps to build Lambda functions in the `deployment/awslocal/deploy.sh` script. However, this conflicts with the quickstart documentation, which requires users (especially on macOS) to build Lambdas separately using a specific Docker image (http://public.ecr.aws/sam/build-python3.11) with `bin/build_lambdas.sh` script.

The conflict caused a problem: when S3 bucket notifications triggered the Lambda function, it couldn't properly load required packages (like PIL), preventing the image resize operation from working correctly.