### PR TITLE
Refactor CircleCI config for LocalStack setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,17 @@
 version: 2.1
 
-
-orbs:
-  localstack: localstack/platform@2.1
-
-
 jobs:
   save-state:
-    executor: localstack/default
+    machine:
+      image: ubuntu-2204:current
+    environment:
+      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN}
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      DEBUG: 1
+      LS_LOG: trace
     steps:
       - checkout
       - restore_cache:
@@ -20,22 +24,24 @@ jobs:
             # Currently highest available 3.11 on CircleCI runner
             test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
             pyenv global 3.11.1
-      - localstack/start        
+      - run:
+          name: Install LocalStack CLI
+          command: python3 -m pip install localstack awscli-local[ver1]
+      - run:
+          name: Start LocalStack
+          command: |
+            docker pull localstack/localstack:latest
+            localstack start -d
+            localstack wait -t 60
       - run:
           name: Install dependencies
-          command:
-            pip3 install -r requirements-dev.txt --upgrade
-      - localstack/wait
+          command: pip3 install -r requirements-dev.txt --upgrade
       - run:
           name: Build lambdas
-          command:
-            deployment/build-lambdas.sh
-            
+          command: deployment/build-lambdas.sh
       - run:
           name: Deploy infrastructure
-          command:
-            deployment/awslocal/deploy.sh
-            
+          command: deployment/awslocal/deploy.sh
       - run:
           name: Export state
           command: localstack state export ls-state.zip
@@ -50,30 +56,36 @@ jobs:
       - store_artifacts:
           path: ls-state.zip
 
-
   load-state:
-    executor: localstack/default
+    machine:
+      image: ubuntu-2204:current
     environment:
-        AWS_DEFAULT_REGION: us-east-1
-        AWS_REGION: us-east-1
-        AWS_ACCESS_KEY_ID: test
-        AWS_SECRET_ACCESS_KEY: test
-        DEBUG: 1
-        LS_LOG: trace
+      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN}
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      DEBUG: 1
+      LS_LOG: trace
     steps:
+      - checkout
       - restore_cache:
           key: python-deps-
       - run:
           name: Choose python version
-          command:
-            pyenv global 3.11.1
-      - localstack/start        
-      - checkout
+          command: pyenv global 3.11.1
+      - run:
+          name: Install LocalStack CLI
+          command: python3 -m pip install localstack awscli-local[ver1]
+      - run:
+          name: Start LocalStack
+          command: |
+            docker pull localstack/localstack:latest
+            localstack start -d
+            localstack wait -t 60
       - run:
           name: Install dependencies
-          command:
-            pip3 install -r requirements-dev.txt
-      - localstack/wait
+          command: pip3 install -r requirements-dev.txt
       - attach_workspace:
           at: .
       - run:
@@ -81,15 +93,13 @@ jobs:
           command: test -f ls-state.zip && localstack state import ls-state.zip
       - run:
           name: Run Tests
-          command:
-            pytest tests
+          command: pytest tests
       - run:
           when: on_fail
           name: Dump Localstack logs
           command: localstack logs | tee localstack.log
       - store_artifacts:
           path: localstack.log
-
 
 workflows:
   do-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pytest tests
+          command: pip3 insyall pytest && pytest tests
 
       - run:
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pip3 install pytest && pytest tests
+          command: pip3 install pytest && python3 -m pytest tests
 
       - run:
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,18 +29,6 @@ jobs:
             echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
 
       - run:
-          name: Verify and configure LocalStack token
-          command: |
-            source "$BASH_ENV"
-            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
-              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
-              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
-              exit 1
-            fi
-            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
-            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
-
-      - run:
           name: Start LocalStack
           command: |
             source "$BASH_ENV"
@@ -100,18 +88,6 @@ jobs:
             python3 -m pip install --user --upgrade pip
             python3 -m pip install --user localstack awscli-local[ver1]
             echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
-
-      - run:
-          name: Verify and configure LocalStack token
-          command: |
-            source "$BASH_ENV"
-            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
-              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
-              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
-              exit 1
-            fi
-            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
-            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
 
       - run:
           name: Start LocalStack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,6 @@ jobs:
             test -f ls-state.zip && localstack state import ls-state.zip
 
       - run:
-          name: Run tests
-          command: pip3 install pytest && python3 -m pytest tests
-
-      - run:
           when: on_fail
           name: Dump LocalStack logs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: pip3 insyall pytest && pytest tests
+          command: pip3 install pytest && pytest tests
 
       - run:
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     machine:
       image: ubuntu-2204:current
     environment:
-      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN}
       AWS_DEFAULT_REGION: us-east-1
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
@@ -21,45 +20,62 @@ jobs:
           keys:
             - python-deps-{{ checksum "requirements-dev.txt" }}
             - python-deps
-      # - run:
-      #     name: Install Python 3.11
-      #     command: |
-      #       test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
-      #       pyenv global 3.11.1
+
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            pip3 install localstack awscli-local[ver1]
-            # echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+
+      - run:
+          name: Verify and configure LocalStack token
+          command: |
+            source "$BASH_ENV"
+            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
+              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
+              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
+              exit 1
+            fi
+            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
+            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
+
       - run:
           name: Start LocalStack
           command: |
-            # source "$BASH_ENV"
+            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
+
       - run:
           name: Install dependencies
           command: pip3 install -r requirements-dev.txt --upgrade
+
       - run:
           name: Build lambdas
           command: deployment/build-lambdas.sh
+
       - run:
           name: Deploy infrastructure
           command: deployment/awslocal/deploy.sh
+
       - run:
           name: Export state
           command: |
             source "$BASH_ENV"
             localstack state export ls-state.zip
+
       - persist_to_workspace:
           root: .
           paths:
             - ls-state.zip
+
       - save_cache:
           paths:
             - /opt/circleci/.pyenv/versions/3.11.1
           key: python-deps-{{ checksum "requirements-dev.txt" }}
+
       - store_artifacts:
           path: ls-state.zip
 
@@ -67,7 +83,6 @@ jobs:
     machine:
       image: ubuntu-2204:current
     environment:
-      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN}
       AWS_DEFAULT_REGION: us-east-1
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
@@ -78,35 +93,58 @@ jobs:
       - checkout
       - restore_cache:
           key: python-deps-
+
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            pip3 install localstack awscli-local[ver1]
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+
+      - run:
+          name: Verify and configure LocalStack token
+          command: |
+            source "$BASH_ENV"
+            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
+              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
+              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
+              exit 1
+            fi
+            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
+            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
+
       - run:
           name: Start LocalStack
           command: |
+            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
+
       - run:
           name: Install dependencies
           command: pip3 install -r requirements-dev.txt
+
       - attach_workspace:
           at: .
+
       - run:
           name: Import state
           command: |
             source "$BASH_ENV"
             test -f ls-state.zip && localstack state import ls-state.zip
+
       - run:
           name: Run tests
           command: pytest tests
+
       - run:
           when: on_fail
           name: Dump LocalStack logs
           command: |
             source "$BASH_ENV"
             localstack logs | tee localstack.log
+
       - store_artifacts:
           path: localstack.log
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  python: circleci/python@4.0.0
+
 jobs:
   save-state:
     machine:
@@ -18,21 +21,20 @@ jobs:
           keys:
             - python-deps-{{ checksum "requirements-dev.txt" }}
             - python-deps
-      - run:
-          name: Install Python 3.11
-          command: |
-            test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
-            pyenv global 3.11.1
+      # - run:
+      #     name: Install Python 3.11
+      #     command: |
+      #       test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
+      #       pyenv global 3.11.1
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            python3 -m pip install --user --upgrade pip
-            python3 -m pip install --user localstack awscli-local[ver1]
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+            pip3 install localstack awscli-local[ver1]
+            # echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
       - run:
           name: Start LocalStack
           command: |
-            source "$BASH_ENV"
+            # source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
@@ -77,18 +79,12 @@ jobs:
       - restore_cache:
           key: python-deps-
       - run:
-          name: Choose Python version
-          command: pyenv global 3.11.1
-      - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            python3 -m pip install --user --upgrade pip
-            python3 -m pip install --user localstack awscli-local[ver1]
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+            pip3 install localstack awscli-local[ver1]
       - run:
           name: Start LocalStack
           command: |
-            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,12 @@ jobs:
           name: Install LocalStack CLI + awslocal
           command: |
             pip3 localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
 
       - run:
           name: Start LocalStack
           command: |
+            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
@@ -48,6 +50,7 @@ jobs:
       - run:
           name: Export state
           command: |
+            source "$BASH_ENV"
             localstack state export ls-state.zip
 
       - persist_to_workspace:
@@ -82,6 +85,7 @@ jobs:
           name: Install LocalStack CLI + awslocal
           command: |
             pip3 install localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
 
       - run:
           name: Start LocalStack
@@ -108,6 +112,7 @@ jobs:
           when: on_fail
           name: Dump LocalStack logs
           command: |
+            source "$BASH_ENV"
             localstack logs | tee localstack.log
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,18 @@ jobs:
       - run:
           name: Install Python 3.11
           command: |
-            # Currently highest available 3.11 on CircleCI runner
             test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
             pyenv global 3.11.1
       - run:
-          name: Install LocalStack CLI
-          command: python3 -m pip install localstack awscli-local[ver1]
+          name: Install LocalStack CLI + awslocal
+          command: |
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
       - run:
           name: Start LocalStack
           command: |
+            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
@@ -44,7 +47,9 @@ jobs:
           command: deployment/awslocal/deploy.sh
       - run:
           name: Export state
-          command: localstack state export ls-state.zip
+          command: |
+            source "$BASH_ENV"
+            localstack state export ls-state.zip
       - persist_to_workspace:
           root: .
           paths:
@@ -72,14 +77,18 @@ jobs:
       - restore_cache:
           key: python-deps-
       - run:
-          name: Choose python version
+          name: Choose Python version
           command: pyenv global 3.11.1
       - run:
-          name: Install LocalStack CLI
-          command: python3 -m pip install localstack awscli-local[ver1]
+          name: Install LocalStack CLI + awslocal
+          command: |
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
       - run:
           name: Start LocalStack
           command: |
+            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
@@ -90,14 +99,18 @@ jobs:
           at: .
       - run:
           name: Import state
-          command: test -f ls-state.zip && localstack state import ls-state.zip
+          command: |
+            source "$BASH_ENV"
+            test -f ls-state.zip && localstack state import ls-state.zip
       - run:
-          name: Run Tests
+          name: Run tests
           command: pytest tests
       - run:
           when: on_fail
-          name: Dump Localstack logs
-          command: localstack logs | tee localstack.log
+          name: Dump LocalStack logs
+          command: |
+            source "$BASH_ENV"
+            localstack logs | tee localstack.log
       - store_artifacts:
           path: localstack.log
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,21 @@ jobs:
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            pip3 localstack awscli-local[ver1]
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
             echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+
+      - run:
+          name: Verify and configure LocalStack token
+          command: |
+            source "$BASH_ENV"
+            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
+              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
+              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
+              exit 1
+            fi
+            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
+            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
 
       - run:
           name: Start LocalStack
@@ -84,8 +97,21 @@ jobs:
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            pip3 install localstack awscli-local[ver1]
+            python3 -m pip install --user --upgrade pip
+            python3 -m pip install --user localstack awscli-local[ver1]
             echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
+
+      - run:
+          name: Verify and configure LocalStack token
+          command: |
+            source "$BASH_ENV"
+            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
+              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
+              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
+              exit 1
+            fi
+            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
+            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
 
       - run:
           name: Start LocalStack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,26 +24,11 @@ jobs:
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            python3 -m pip install --user --upgrade pip
-            python3 -m pip install --user localstack awscli-local[ver1]
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
-
-      - run:
-          name: Verify and configure LocalStack token
-          command: |
-            source "$BASH_ENV"
-            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
-              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
-              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
-              exit 1
-            fi
-            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
-            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
+            pip3 localstack awscli-local[ver1]
 
       - run:
           name: Start LocalStack
           command: |
-            source "$BASH_ENV"
             docker pull localstack/localstack:latest
             localstack start -d
             localstack wait -t 60
@@ -63,7 +48,6 @@ jobs:
       - run:
           name: Export state
           command: |
-            source "$BASH_ENV"
             localstack state export ls-state.zip
 
       - persist_to_workspace:
@@ -97,21 +81,7 @@ jobs:
       - run:
           name: Install LocalStack CLI + awslocal
           command: |
-            python3 -m pip install --user --upgrade pip
-            python3 -m pip install --user localstack awscli-local[ver1]
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> "$BASH_ENV"
-
-      - run:
-          name: Verify and configure LocalStack token
-          command: |
-            source "$BASH_ENV"
-            if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
-              echo "LOCALSTACK_AUTH_TOKEN is not set in this job."
-              echo "Set it in CircleCI Project Settings > Environment Variables or via Context."
-              exit 1
-            fi
-            echo "LOCALSTACK_AUTH_TOKEN is present (length=${#LOCALSTACK_AUTH_TOKEN})"
-            localstack auth set-token "$LOCALSTACK_AUTH_TOKEN"
+            pip3 install localstack awscli-local[ver1]
 
       - run:
           name: Start LocalStack
@@ -138,7 +108,6 @@ jobs:
           when: on_fail
           name: Dump LocalStack logs
           command: |
-            source "$BASH_ENV"
             localstack logs | tee localstack.log
 
       - store_artifacts:

--- a/lambdas/resize/requirements.txt
+++ b/lambdas/resize/requirements.txt
@@ -1,1 +1,1 @@
-Pillow==9.2.0
+Pillow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 boto3
 requests>=2.20
-Pillow==9.2.0
+Pillow
 mypy-boto3-ssm
 mypy-boto3-sns
 mypy-boto3-s3


### PR DESCRIPTION
Updated CircleCI configuration to use a machine executor with Ubuntu 22.04, removed localstack orb, and adjusted job steps for LocalStack installation and usage.